### PR TITLE
 changed server memory free strategy. Now instead of delete memory to…

### DIFF
--- a/src/kvraft/common.go
+++ b/src/kvraft/common.go
@@ -11,6 +11,13 @@ const (
 
 type Err string
 
+type DeletePrevRequestArgs struct {
+	PrevRequests []int64
+}
+type DeletePrevRequestReply struct {
+	Err Err
+}
+
 // Put or Append
 type PutAppendArgs struct {
 	Key   string
@@ -22,7 +29,7 @@ type PutAppendArgs struct {
 
 	Serial_Number int64
 
-	PrevRequests []int64
+	//PrevRequests []int64
 }
 
 type PutAppendReply struct {
@@ -38,7 +45,7 @@ type GetArgs struct {
 
 	Serial_Number int64
 
-	PrevRequests []int64
+	//PrevRequests []int64
 }
 
 type GetReply struct {


### PR DESCRIPTION
… servers that receives each get or putappend rpc call, the client initiate delete request to all servers following completion of a request. This free memory in multiple servers in a more timely fashion at expense of more rpc call, which consumes network bandwidth.